### PR TITLE
update zipkin-transport-http to 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "tcp-ping": "^0.1.1",
         "zipkin": "0.10.1",
         "zipkin-context-cls": "0.6.1",
-        "zipkin-transport-http": "0.10.1",
+        "zipkin-transport-http": "0.22.0",
         "ibmapm-restclient": ">=20.3.0"
     },
     "devDependencies": {


### PR DESCRIPTION
avoid the risk `https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15168`